### PR TITLE
Allow star comments to have leading whitespace

### DIFF
--- a/Stata.tmLanguage
+++ b/Stata.tmLanguage
@@ -137,7 +137,7 @@
            		</dict>
                 <dict>
                         <key>match</key>
-                        <string>(;\*|^\*|\t\*).*$\n?</string>
+                        <string>(;\*|^\s*\*|\t\*).*$\n?</string>
                         <key>name</key>
                         <string>comment.line.star.stata</string>
                 </dict>


### PR DESCRIPTION
Changed the regular expression in `comment.line.star.stata` to allow comments to have leading whitespace, which is useful if you'd like to comment out just parts of your code that are indented. 

For example,

```
foreach var of varlist one two three {
  summ `var'
  * describe `var'
}
```
