### PR TITLE
add bysort highligting

### DIFF
--- a/Stata.tmLanguage
+++ b/Stata.tmLanguage
@@ -19,7 +19,7 @@
         <array>
                 <dict>
                         <key>match</key>
-                        <string>\b(if|in|for|by|bys|xi|quietly|capture|exit|qui|cap|program|end)\b</string>
+                        <string>\b(if|in|for|by|bys|bysort|xi|quietly|capture|exit|qui|cap|program|end)\b</string>
                         <key>name</key>
                         <string>keyword.control.stata</string>
                 </dict>


### PR DESCRIPTION
"bys" is highlighted, but "bysort" isn't. Fixed.