### PR TITLE
Permit characters after line continuation

### DIFF
--- a/text_2_stata.py
+++ b/text_2_stata.py
@@ -15,7 +15,7 @@ def strip_inline_comments(text):
 	clean = text
 
 	# Take care of line continuation
-	clean = re.sub("/{3,}\\n", " ", clean)
+	clean = re.sub("/{3,}.*\\n", " ", clean)
 
 	# Remove /* ... */ comments (handles multiple lines) + // comments
 	#


### PR DESCRIPTION
Fixes comments and whitespace after line continuation characters (///). Fixes andrewheiss/SublimeStataEnhanced#23.