### PR TITLE
Update StataIndentation Rules.tmPreferences

### DIFF
--- a/StataIndentation Rules.tmPreferences
+++ b/StataIndentation Rules.tmPreferences
@@ -10,21 +10,17 @@
 		<dict>
 			<key>decreaseIndentPattern</key>
 			<string>(?x)
-			^.*\}.*$
+			^\s*\}\s*$
 			|^\s*end\s*$
 			</string>
 			<key>increaseIndentPattern</key>
 			<string>(?x)
-			^mata\:$	
-			|^.*\{.*$
+			^.*\{\s*$
+			|^mata\:$	
 			|^\s*program\s*define.*$
 			</string>
-			<key>unIndentedLinePattern</key>
-			<string></string>
-			<key>bracketIndentNextLinePattern</key>
-			<string></string>
-			<key>disableIndentNextLinePattern</key>
-			<string></string>
+			<key>indentParens</key>
+			<false/>
 		</dict>
 		<key>uuid</key>
 		<string>C49120AC-6ECC-11D9-ACC8-000D93589AF6</string>


### PR DESCRIPTION
Since I made the last pull request, I change indentParens to false. This avoids indentation due to comments of the form 
```
/* comment ( */
```
I forgot to update the pull request with this change.